### PR TITLE
feat: /api/admin 을 prefix로 하는 category, products router 생성 (temporary)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1065,6 +1065,11 @@
         "uuid": "8.3.2"
       }
     },
+    "@nestjs/mapped-types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-1.1.0.tgz",
+      "integrity": "sha512-+2kSly4P1QI+9eGt+/uGyPdEG1hVz7nbpqPHWZVYgoqz8eOHljpXPag+UCVRw9zo2XCu4sgNUIGe8Uk0+OvUQg=="
+    },
     "@nestjs/platform-express": {
       "version": "8.4.7",
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-8.4.7.tgz",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@nestjs/common": "^8.0.0",
     "@nestjs/core": "^8.0.0",
+    "@nestjs/mapped-types": "*",
     "@nestjs/platform-express": "^8.0.0",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",

--- a/src/admin/admin.controller.spec.ts
+++ b/src/admin/admin.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AdminController } from './admin.controller';
+import { AdminService } from './admin.service';
+
+describe('AdminController', () => {
+  let controller: AdminController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AdminController],
+      providers: [AdminService],
+    }).compile();
+
+    controller = module.get<AdminController>(AdminController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -1,0 +1,15 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+} from '@nestjs/common';
+import { AdminService } from './admin.service';
+import { CreateAdminDto } from './dto/create-admin.dto';
+import { UpdateAdminDto } from './dto/update-admin.dto';
+
+@Controller('admin')
+export class AdminController {}

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { AdminService } from './admin.service';
+import { AdminController } from './admin.controller';
+import { RouterModule } from '@nestjs/core';
+import { CategoryModule } from 'src/category/category.module';
+import { CategoryController } from 'src/category/category.controller';
+import { CategoryService } from 'src/category/category.service';
+import { ProductsModule } from 'src/products/products.module';
+
+@Module({
+  // controllers: [AdminController],
+  // providers: [AdminService],
+  imports: [CategoryModule, ProductsModule],
+})
+export class AdminModule {}

--- a/src/admin/admin.service.spec.ts
+++ b/src/admin/admin.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AdminService } from './admin.service';
+
+describe('AdminService', () => {
+  let service: AdminService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AdminService],
+    }).compile();
+
+    service = module.get<AdminService>(AdminService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { CreateAdminDto } from './dto/create-admin.dto';
+import { UpdateAdminDto } from './dto/update-admin.dto';
+
+@Injectable()
+export class AdminService {
+  create(createAdminDto: CreateAdminDto) {
+    return 'This action adds a new admin';
+  }
+
+  findAll() {
+    return `This action returns all admin`;
+  }
+
+  findOne(id: number) {
+    return `This action returns a #${id} admin`;
+  }
+
+  update(id: number, updateAdminDto: UpdateAdminDto) {
+    return `This action updates a #${id} admin`;
+  }
+
+  remove(id: number) {
+    return `This action removes a #${id} admin`;
+  }
+}

--- a/src/admin/dto/create-admin.dto.ts
+++ b/src/admin/dto/create-admin.dto.ts
@@ -1,0 +1,1 @@
+export class CreateAdminDto {}

--- a/src/admin/dto/update-admin.dto.ts
+++ b/src/admin/dto/update-admin.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateAdminDto } from './create-admin.dto';
+
+export class UpdateAdminDto extends PartialType(CreateAdminDto) {}

--- a/src/admin/entities/admin.entity.ts
+++ b/src/admin/entities/admin.entity.ts
@@ -1,0 +1,1 @@
+export class Admin {}

--- a/src/api/api.controller.spec.ts
+++ b/src/api/api.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ApiController } from './api.controller';
+import { ApiService } from './api.service';
+
+describe('ApiController', () => {
+  let controller: ApiController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ApiController],
+      providers: [ApiService],
+    }).compile();
+
+    controller = module.get<ApiController>(ApiController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/api/api.controller.ts
+++ b/src/api/api.controller.ts
@@ -1,0 +1,20 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+} from '@nestjs/common';
+
+import { CreateApiDto } from './dto/create-api.dto';
+import { UpdateApiDto } from './dto/update-api.dto';
+
+@Controller('api')
+export class ApiController {
+  @Get()
+  index(): string {
+    return 'Hello, API';
+  }
+}

--- a/src/api/api.module.ts
+++ b/src/api/api.module.ts
@@ -1,0 +1,30 @@
+import { Module } from '@nestjs/common';
+import { RouterModule } from '@nestjs/core';
+import { AdminModule } from 'src/admin/admin.module';
+import { CategoryModule } from 'src/category/category.module';
+import { ProductsModule } from 'src/products/products.module';
+import { ApiController } from './api.controller';
+
+@Module({
+  // controllers: [ApiController],
+  imports: [
+    AdminModule,
+    RouterModule.register([
+      {
+        path: 'api',
+        module: AdminModule,
+        children: [
+          {
+            path: 'admin',
+            module: CategoryModule,
+          },
+          {
+            path: 'admin',
+            module: ProductsModule,
+          },
+        ],
+      },
+    ]),
+  ],
+})
+export class ApiModule {}

--- a/src/api/dto/create-api.dto.ts
+++ b/src/api/dto/create-api.dto.ts
@@ -1,0 +1,1 @@
+export class CreateApiDto {}

--- a/src/api/dto/update-api.dto.ts
+++ b/src/api/dto/update-api.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateApiDto } from './create-api.dto';
+
+export class UpdateApiDto extends PartialType(CreateApiDto) {}

--- a/src/api/entities/api.entity.ts
+++ b/src/api/entities/api.entity.ts
@@ -1,0 +1,1 @@
+export class Api {}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,9 +2,19 @@ import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 
+// import { AdminModule } from './admin/admin.module';
+import { ProductsModule } from './products/products.module';
+import { ApiModule } from './api/api.module';
+import { CategoryModule } from './category/category.module';
+import { AdminModule } from './admin/admin.module';
+import { ApiController } from './api/api.controller';
+import { RouterModule } from '@nestjs/core';
+// import { AdminModule } from './admin/admin.module';
+
 @Module({
-  imports: [],
+  // imports: [AdminModule],
   controllers: [AppController],
   providers: [AppService],
+  imports: [ApiModule, ProductsModule],
 })
 export class AppModule {}

--- a/src/category/category.controller.spec.ts
+++ b/src/category/category.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CategoryController } from './category.controller';
+import { CategoryService } from './category.service';
+
+describe('CategoryController', () => {
+  let controller: CategoryController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CategoryController],
+      providers: [CategoryService],
+    }).compile();
+
+    controller = module.get<CategoryController>(CategoryController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/category/category.controller.ts
+++ b/src/category/category.controller.ts
@@ -1,0 +1,60 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+} from '@nestjs/common';
+import { CategoryService } from './category.service';
+import { CreateCategoryDto } from './dto/create-category.dto';
+import { UpdateCategoryDto } from './dto/update-category.dto';
+
+@Controller('category')
+export class CategoryController {
+  constructor(private readonly categoryService: CategoryService) {}
+
+  @Post()
+  create(@Body() createCategoryDto: CreateCategoryDto) {
+    return this.categoryService.create(createCategoryDto);
+  }
+
+  @Get()
+  findAll() {
+    // TODO: find all categories in Database and format them according to their level.
+
+    const categoryObject = {
+      'New Releases': [],
+      Men: [],
+      Women: [],
+      Kids: [],
+      Sale: [],
+    };
+
+    // for (const key in categoryObject) {
+    //   console.log(key);
+    // }
+
+    return categoryObject;
+    // return this.categoryService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.categoryService.findOne(+id);
+  }
+
+  @Patch(':id')
+  update(
+    @Param('id') id: string,
+    @Body() updateCategoryDto: UpdateCategoryDto,
+  ) {
+    return this.categoryService.update(+id, updateCategoryDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.categoryService.remove(+id);
+  }
+}

--- a/src/category/category.module.ts
+++ b/src/category/category.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { CategoryService } from './category.service';
+import { CategoryController } from './category.controller';
+
+@Module({
+  controllers: [CategoryController],
+  providers: [CategoryService],
+  exports: [CategoryService],
+})
+export class CategoryModule {}

--- a/src/category/category.service.spec.ts
+++ b/src/category/category.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CategoryService } from './category.service';
+
+describe('CategoryService', () => {
+  let service: CategoryService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [CategoryService],
+    }).compile();
+
+    service = module.get<CategoryService>(CategoryService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/category/category.service.ts
+++ b/src/category/category.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { CreateCategoryDto } from './dto/create-category.dto';
+import { UpdateCategoryDto } from './dto/update-category.dto';
+
+@Injectable()
+export class CategoryService {
+  create(createCategoryDto: CreateCategoryDto) {
+    return 'This action adds a new category';
+  }
+
+  findAll() {
+    return `This action returns all category`;
+  }
+
+  findOne(id: number) {
+    return `This action returns a #${id} category`;
+  }
+
+  update(id: number, updateCategoryDto: UpdateCategoryDto) {
+    return `This action updates a #${id} category`;
+  }
+
+  remove(id: number) {
+    return `This action removes a #${id} category`;
+  }
+}

--- a/src/category/dto/create-category.dto.ts
+++ b/src/category/dto/create-category.dto.ts
@@ -1,0 +1,1 @@
+export class CreateCategoryDto {}

--- a/src/category/dto/update-category.dto.ts
+++ b/src/category/dto/update-category.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateCategoryDto } from './create-category.dto';
+
+export class UpdateCategoryDto extends PartialType(CreateCategoryDto) {}

--- a/src/category/entities/category.entity.ts
+++ b/src/category/entities/category.entity.ts
@@ -1,0 +1,1 @@
+export class Category {}

--- a/src/products/dto/create-product.dto.ts
+++ b/src/products/dto/create-product.dto.ts
@@ -1,0 +1,1 @@
+export class CreateProductDto {}

--- a/src/products/dto/update-product.dto.ts
+++ b/src/products/dto/update-product.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateProductDto } from './create-product.dto';
+
+export class UpdateProductDto extends PartialType(CreateProductDto) {}

--- a/src/products/entities/product.entity.ts
+++ b/src/products/entities/product.entity.ts
@@ -1,0 +1,1 @@
+export class Product {}

--- a/src/products/products.controller.spec.ts
+++ b/src/products/products.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProductsController } from './products.controller';
+import { ProductsService } from './products.service';
+
+describe('ProductsController', () => {
+  let controller: ProductsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ProductsController],
+      providers: [ProductsService],
+    }).compile();
+
+    controller = module.get<ProductsController>(ProductsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/products/products.controller.ts
+++ b/src/products/products.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { ProductsService } from './products.service';
+import { CreateProductDto } from './dto/create-product.dto';
+import { UpdateProductDto } from './dto/update-product.dto';
+
+@Controller('products')
+export class ProductsController {
+  constructor(private readonly productsService: ProductsService) {}
+
+  @Post()
+  create(@Body() createProductDto: CreateProductDto) {
+    return this.productsService.create(createProductDto);
+  }
+
+  @Get()
+  findAll() {
+    return this.productsService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.productsService.findOne(+id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() updateProductDto: UpdateProductDto) {
+    return this.productsService.update(+id, updateProductDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.productsService.remove(+id);
+  }
+}

--- a/src/products/products.module.ts
+++ b/src/products/products.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ProductsService } from './products.service';
+import { ProductsController } from './products.controller';
+
+@Module({
+  controllers: [ProductsController],
+  providers: [ProductsService]
+})
+export class ProductsModule {}

--- a/src/products/products.service.spec.ts
+++ b/src/products/products.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProductsService } from './products.service';
+
+describe('ProductsService', () => {
+  let service: ProductsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ProductsService],
+    }).compile();
+
+    service = module.get<ProductsService>(ProductsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/products/products.service.ts
+++ b/src/products/products.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { CreateProductDto } from './dto/create-product.dto';
+import { UpdateProductDto } from './dto/update-product.dto';
+
+@Injectable()
+export class ProductsService {
+  create(createProductDto: CreateProductDto) {
+    return 'This action adds a new product';
+  }
+
+  findAll() {
+    return `This action returns all products`;
+  }
+
+  findOne(id: number) {
+    return `This action returns a #${id} product`;
+  }
+
+  update(id: number, updateProductDto: UpdateProductDto) {
+    return `This action updates a #${id} product`;
+  }
+
+  remove(id: number) {
+    return `This action removes a #${id} product`;
+  }
+}


### PR DESCRIPTION
- GET /api/admin/category 는 임시로 dummy category object를 반환함 

#2  